### PR TITLE
Coding standards and line reference fixes for unit tests.

### DIFF
--- a/Sniffs/PHP/RemovedFunctionParametersSniff.php
+++ b/Sniffs/PHP/RemovedFunctionParametersSniff.php
@@ -92,7 +92,7 @@ extends PHP53to54_AbstractSniff
         $parameterRegExps = $this->forbiddenFunctionsParameters[$functionName];
         foreach ($parameterTokens as $index => $parameterToken) {
             // only look at first function parameters
-            if ($index > 0) {
+            if ($index > 1) {
                 continue;
             }
             $tokenContent = $parameterToken['content'];

--- a/tests/README
+++ b/tests/README
@@ -1,7 +1,12 @@
-In order to run tests link from/ copy to CodeSniffer tests path.
+In order to run the test you will need to link PHP53to54 to your PHP_CodeSniffer
+test path.
 
-For Ubuntu (maybe other GNU/Linux) that is `/usr/share/php/test/PHP_CodeSniffer/Standards/`.
+For Ubuntu that is /usr/share/php/test/PHP_CodeSniffer/CodeSniffer/Standards/.
 
-Now run
-# cd /path/to/PHP_CodeSniffer/
-# phpunit --bootstrap AllTests.php Standards/PHP53to54/
+Now you can either run all CodeSniffer tests like
+
+# phpunit --bootstrap /path/to/AllTests.php /path/to/test/Standards
+
+or single tests only with
+
+# phpunit --bootstrap /path/to/AllTests.php /path/to/tests/Standards/PHP53to54/ 

--- a/tests/Standards/PHP53to54/AbstractSniffUnitTest.php
+++ b/tests/Standards/PHP53to54/AbstractSniffUnitTest.php
@@ -1,9 +1,0 @@
-<?php
-
-abstract class PHP53to54_AbstractSniffUnitTest
-extends AbstractSniffUnitTest
-{
-    public function testVoid()
-    {
-    }
-}

--- a/tests/Standards/PHP53to54/Tests/Deprecated/FunctionAliasesUnitTest.php
+++ b/tests/Standards/PHP53to54/Tests/Deprecated/FunctionAliasesUnitTest.php
@@ -5,30 +5,31 @@
  *
  * PHP version 5
  *
- * @category PHP
- * @package PHP_CodeSniffer
- * @author Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
  * @copyright 2012 foobugs oelke & eichner GbR
- * @license BSD http://www.opensource.org/licenses/bsd-license.php
- * @link https://github.com/foobugs/PHP53to54
- * @since 1.0-beta
+ * @license   BSD http://www.opensource.org/licenses/bsd-license.php
+ * @link      https://github.com/foobugs/PHP53to54
+ * @since     1.0-beta
  */
 
 /**
  * Unit Test for Deprecated/FunctionAliases Sniff
  *
- * @group PHP53to54
- * @category PHP
- * @package PHP_CodeSniffer
- * @author Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
+ * @group     PHP53to54
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
  * @copyright 2012 foobugs oelke & eichner GbR
- * @license BSD http://www.opensource.org/licenses/bsd-license.php
- * @link https://github.com/foobugs/PHP53to54
- * @since 1.0-beta
+ * @license   BSD http://www.opensource.org/licenses/bsd-license.php
+ * @link      https://github.com/foobugs/PHP53to54
+ * @since     1.0-beta
  */
-class PHP53to54_Tests_Deprecated_FunctionAliasesUnitTest extends PHP53to54_AbstractSniffUnitTest
+class PHP53to54_Tests_Deprecated_FunctionAliasesUnitTest
+extends AbstractSniffUnitTest
 {
-	/**
+    /**
      * Returns the lines where errors should occur.
      *
      * The key of the array should represent the line number and the value
@@ -36,15 +37,15 @@ class PHP53to54_Tests_Deprecated_FunctionAliasesUnitTest extends PHP53to54_Abstr
      *
      * @return array(int => int)
      */
-	public function getErrorList()
-	{
-		return array(
-			3 => 1,
-			5 => 1,
-		);
-	}
-	
-	/**
+    public function getErrorList()
+    {
+        return array(
+                3 => 1,
+                5 => 1,
+        );
+    }
+
+    /**
      * Returns the lines where warnings should occur.
      *
      * The key of the array should represent the line number and the value
@@ -52,9 +53,9 @@ class PHP53to54_Tests_Deprecated_FunctionAliasesUnitTest extends PHP53to54_Abstr
      *
      * @return array(int => int)
      */
-	public function getWarningList()
-	{
+    public function getWarningList()
+    {
         return array(
-		);
+        );
     }
 }

--- a/tests/Standards/PHP53to54/Tests/Deprecated/FunctionsUnitTest.php
+++ b/tests/Standards/PHP53to54/Tests/Deprecated/FunctionsUnitTest.php
@@ -5,30 +5,31 @@
  *
  * PHP version 5
  *
- * @category PHP
- * @package PHP_CodeSniffer
- * @author Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
  * @copyright 2012 foobugs oelke & eichner GbR
- * @license BSD http://www.opensource.org/licenses/bsd-license.php
- * @link https://github.com/foobugs/PHP53to54
- * @since 1.0-beta
+ * @license   BSD http://www.opensource.org/licenses/bsd-license.php
+ * @link      https://github.com/foobugs/PHP53to54
+ * @since     1.0-beta
  */
 
 /**
  * Unit Test for Deprecated/Functions Sniff
  *
- * @group PHP53to54
- * @category PHP
- * @package PHP_CodeSniffer
- * @author Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
+ * @group     PHP53to54
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
  * @copyright 2012 foobugs oelke & eichner GbR
- * @license BSD http://www.opensource.org/licenses/bsd-license.php
- * @link https://github.com/foobugs/PHP53to54
- * @since 1.0-beta
+ * @license   BSD http://www.opensource.org/licenses/bsd-license.php
+ * @link      https://github.com/foobugs/PHP53to54
+ * @since     1.0-beta
  */
-class PHP53to54_Tests_Deprecated_FunctionsUnitTest extends PHP53to54_AbstractSniffUnitTest
+class PHP53to54_Tests_Deprecated_FunctionsUnitTest
+extends AbstractSniffUnitTest
 {
-	/**
+    /**
      * Returns the lines where errors should occur.
      *
      * The key of the array should represent the line number and the value
@@ -36,12 +37,15 @@ class PHP53to54_Tests_Deprecated_FunctionsUnitTest extends PHP53to54_AbstractSni
      *
      * @return array(int => int)
      */
-	public function getErrorList()
-	{
-		return array();
-	}
-	
-	/**
+    public function getErrorList()
+    {
+        return array(
+            3 => 1,
+            5 => 1,
+        );
+    }
+
+    /**
      * Returns the lines where warnings should occur.
      *
      * The key of the array should represent the line number and the value
@@ -49,11 +53,9 @@ class PHP53to54_Tests_Deprecated_FunctionsUnitTest extends PHP53to54_AbstractSni
      *
      * @return array(int => int)
      */
-	public function getWarningList()
-	{
+    public function getWarningList()
+    {
         return array(
-			3 => 2,
-			5 => 1,
-		);
+        );
     }
 }

--- a/tests/Standards/PHP53to54/Tests/Extensions/SQLiteConstantsUnitTest.php
+++ b/tests/Standards/PHP53to54/Tests/Extensions/SQLiteConstantsUnitTest.php
@@ -5,29 +5,29 @@
  *
  * PHP version 5
  *
- * @category PHP
- * @package PHP_CodeSniffer
- * @author Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
  * @copyright 2012 foobugs oelke & eichner GbR
- * @license BSD http://www.opensource.org/licenses/bsd-license.php
- * @link https://github.com/foobugs/PHP53to54
- * @since 1.0-beta
+ * @license   BSD http://www.opensource.org/licenses/bsd-license.php
+ * @link      https://github.com/foobugs/PHP53to54
+ * @since     1.0-beta
  */
 
 /**
  * Unit test class for Extensions/SQLiteConstantSniff
  *
- * @group PHP53to54
- * @category PHP
- * @package PHP_CodeSniffer
- * @author Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
+ * @group     PHP53to54
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
  * @copyright 2012 foobugs oelke & eichner GbR
- * @license BSD http://www.opensource.org/licenses/bsd-license.php
- * @link https://github.com/foobugs/PHP53to54
- * @since 1.0-beta
+ * @license   BSD http://www.opensource.org/licenses/bsd-license.php
+ * @link      https://github.com/foobugs/PHP53to54
+ * @since     1.0-beta
  */
 class PHP53to54_Tests_PHP_SQLiteConstantsUnitTest
-extends PHP53to54_AbstractSniffUnitTest
+extends AbstractSniffUnitTest
 {
     /**
      * Returns the lines where errors should occur.

--- a/tests/Standards/PHP53to54/Tests/Extensions/SQLiteFunctionsUnitTest.php
+++ b/tests/Standards/PHP53to54/Tests/Extensions/SQLiteFunctionsUnitTest.php
@@ -5,31 +5,31 @@
  *
  * PHP version 5
  *
- * @category PHP
- * @package PHP_CodeSniffer
- * @author Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
  * @copyright 2012 foobugs oelke & eichner GbR
- * @license BSD http://www.opensource.org/licenses/bsd-license.php
- * @link https://github.com/foobugs/PHP53to54
- * @since 1.0-beta
+ * @license   BSD http://www.opensource.org/licenses/bsd-license.php
+ * @link      https://github.com/foobugs/PHP53to54
+ * @since     1.0-beta
  */
 
 /**
  * Unit test class for Extensions/SQLiteFunctionsSniff
  *
- * @group PHP53to54
- * @category PHP
- * @package PHP_CodeSniffer
- * @author Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
+ * @group     PHP53to54
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
  * @copyright 2012 foobugs oelke & eichner GbR
- * @license BSD http://www.opensource.org/licenses/bsd-license.php
- * @link https://github.com/foobugs/PHP53to54
- * @since 1.0-beta
+ * @license   BSD http://www.opensource.org/licenses/bsd-license.php
+ * @link      https://github.com/foobugs/PHP53to54
+ * @since     1.0-beta
  */
 class PHP53to54_Tests_PHP_SQLiteFunctionsUnitTest
-extends PHP53to54_AbstractSniffUnitTest
+extends AbstractSniffUnitTest
 {
-	/**
+    /**
      * Returns the lines where errors should occur.
      *
      * The key of the array should represent the line number and the value
@@ -37,14 +37,14 @@ extends PHP53to54_AbstractSniffUnitTest
      *
      * @return array(int => int)
      */
-	public function getErrorList()
-	{
-		return array(
-			11 => 1,
-		);
-	}
+    public function getErrorList()
+    {
+        return array(
+            11 => 1,
+        );
+    }
 
-	/**
+    /**
      * Returns the lines where warnings should occur.
      *
      * The key of the array should represent the line number and the value
@@ -52,9 +52,9 @@ extends PHP53to54_AbstractSniffUnitTest
      *
      * @return array(int => int)
      */
-	public function getWarningList()
-	{
-		return array(
-		);
+    public function getWarningList()
+    {
+        return array(
+        );
     }
 }

--- a/tests/Standards/PHP53to54/Tests/Extensions/SQLiteUnitTest.php
+++ b/tests/Standards/PHP53to54/Tests/Extensions/SQLiteUnitTest.php
@@ -5,31 +5,31 @@
  *
  * PHP version 5
  *
- * @category PHP
- * @package PHP_CodeSniffer
- * @author Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
  * @copyright 2012 foobugs oelke & eichner GbR
- * @license BSD http://www.opensource.org/licenses/bsd-license.php
- * @link https://github.com/foobugs/PHP53to54
- * @since 1.0-beta
+ * @license   BSD http://www.opensource.org/licenses/bsd-license.php
+ * @link      https://github.com/foobugs/PHP53to54
+ * @since     1.0-beta
  */
 
 /**
  * Unit test class for Extensions/SQLiteSniff
  *
- * @group PHP53to54
- * @category PHP
- * @package PHP_CodeSniffer
- * @author Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
+ * @group     PHP53to54
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
  * @copyright 2012 foobugs oelke & eichner GbR
- * @license BSD http://www.opensource.org/licenses/bsd-license.php
- * @link https://github.com/foobugs/PHP53to54
- * @since 1.0-beta
+ * @license   BSD http://www.opensource.org/licenses/bsd-license.php
+ * @link      https://github.com/foobugs/PHP53to54
+ * @since     1.0-beta
  */
 class PHP53to54_Tests_PHP_SQLiteUnitTest
-extends PHP53to54_AbstractSniffUnitTest
+extends AbstractSniffUnitTest
 {
-	/**
+    /**
      * Returns the lines where errors should occur.
      *
      * The key of the array should represent the line number and the value
@@ -37,17 +37,17 @@ extends PHP53to54_AbstractSniffUnitTest
      *
      * @return array(int => int)
      */
-	public function getErrorList()
-	{
-		return array(
-			7 => 1,
-			9 => 1,
-			11 => 1,
-			15 => 1,
-		);
-	}
+    public function getErrorList()
+    {
+        return array(
+            7 => 1,
+            9 => 1,
+            11 => 1,
+            15 => 1,
+        );
+    }
 
-	/**
+    /**
      * Returns the lines where warnings should occur.
      *
      * The key of the array should represent the line number and the value
@@ -55,10 +55,10 @@ extends PHP53to54_AbstractSniffUnitTest
      *
      * @return array(int => int)
      */
-	public function getWarningList()
-	{
-		return array(
-			6 => 1,
-		);
+    public function getWarningList()
+    {
+        return array(
+                6 => 1,
+        );
     }
 }

--- a/tests/Standards/PHP53to54/Tests/Generic/ForbiddenClassNamesUnitTest.1.inc
+++ b/tests/Standards/PHP53to54/Tests/Generic/ForbiddenClassNamesUnitTest.1.inc
@@ -1,10 +1,12 @@
 <?php
 
+
+
 // invalid stuff
 class CallbackFilterIterator {
-	
+
 }
 
 class callbackfilteriterator {
-	
+
 }

--- a/tests/Standards/PHP53to54/Tests/Generic/ForbiddenClassNamesUnitTest.2.inc
+++ b/tests/Standards/PHP53to54/Tests/Generic/ForbiddenClassNamesUnitTest.2.inc
@@ -2,12 +2,12 @@
 
 // valid stuff
 namespace myapp
-{	
+{
 	class CallbackFilterIterator {
-	
+
 	}
 
 	class callbackfilteriterator {
-	
+
 	}
 }

--- a/tests/Standards/PHP53to54/Tests/Generic/ForbiddenClassNamesUnitTest.php
+++ b/tests/Standards/PHP53to54/Tests/Generic/ForbiddenClassNamesUnitTest.php
@@ -5,31 +5,31 @@
  *
  * PHP version 5
  *
- * @category PHP
- * @package PHP_CodeSniffer
- * @author Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
  * @copyright 2012 foobugs oelke & eichner GbR
- * @license BSD http://www.opensource.org/licenses/bsd-license.php
- * @link https://github.com/foobugs/PHP53to54
- * @since 1.0-beta
+ * @license   BSD http://www.opensource.org/licenses/bsd-license.php
+ * @link      https://github.com/foobugs/PHP53to54
+ * @since     1.0-beta
  */
 
 /**
  * Unit test class for PHP/RemovedFunctionParameters sniff.
  *
- * @group PHP53to54
- * @category PHP
- * @package PHP_CodeSniffer
- * @author Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
+ * @group     PHP53to54
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
  * @copyright 2012 foobugs oelke & eichner GbR
- * @license BSD http://www.opensource.org/licenses/bsd-license.php
- * @link https://github.com/foobugs/PHP53to54
- * @since 1.0-beta
+ * @license   BSD http://www.opensource.org/licenses/bsd-license.php
+ * @link      https://github.com/foobugs/PHP53to54
+ * @since     1.0-beta
  */
 class PHP53to54_Tests_Generic_ForbiddenClassNamesUnitTest
-extends PHP53to54_AbstractSniffUnitTest
+extends AbstractSniffUnitTest
 {
-	/**
+    /**
      * Returns the lines where errors should occur.
      *
      * The key of the array should represent the line number and the value
@@ -37,15 +37,15 @@ extends PHP53to54_AbstractSniffUnitTest
      *
      * @return array(int => int)
      */
-	public function getErrorList()
-	{
-		return array(
-			4 => 1,
-			8 => 1,
-		);
-	}
+    public function getErrorList()
+    {
+        return array(
+            6 => 1,
+            10 => 1,
+        );
+    }
 
-	/**
+    /**
      * Returns the lines where warnings should occur.
      *
      * The key of the array should represent the line number and the value
@@ -53,9 +53,9 @@ extends PHP53to54_AbstractSniffUnitTest
      *
      * @return array(int => int)
      */
-	public function getWarningList()
-	{
-		return array(
-		);
+    public function getWarningList()
+    {
+        return array(
+        );
     }
 }

--- a/tests/Standards/PHP53to54/Tests/Generic/ForbiddenConstantNamesUnitTest.php
+++ b/tests/Standards/PHP53to54/Tests/Generic/ForbiddenConstantNamesUnitTest.php
@@ -5,31 +5,31 @@
  *
  * PHP version 5
  *
- * @category PHP
- * @package PHP_CodeSniffer
- * @author Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
  * @copyright 2012 foobugs oelke & eichner GbR
- * @license BSD http://www.opensource.org/licenses/bsd-license.php
- * @link https://github.com/foobugs/PHP53to54
- * @since 1.0-beta
+ * @license   BSD http://www.opensource.org/licenses/bsd-license.php
+ * @link      https://github.com/foobugs/PHP53to54
+ * @since     1.0-beta
  */
 
 /**
  * Unit test class for PHP/RemovedFunctionParameters sniff.
  *
- * @group PHP53to54
- * @category PHP
- * @package PHP_CodeSniffer
- * @author Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
+ * @group     PHP53to54
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
  * @copyright 2012 foobugs oelke & eichner GbR
- * @license BSD http://www.opensource.org/licenses/bsd-license.php
- * @link https://github.com/foobugs/PHP53to54
- * @since 1.0-beta
+ * @license   BSD http://www.opensource.org/licenses/bsd-license.php
+ * @link      https://github.com/foobugs/PHP53to54
+ * @since     1.0-beta
  */
 class PHP53to54_Tests_Generic_ForbiddenConstantNamesUnitTest
-extends PHP53to54_AbstractSniffUnitTest
+extends AbstractSniffUnitTest
 {
-	/**
+    /**
      * Returns the lines where errors should occur.
      *
      * The key of the array should represent the line number and the value
@@ -37,16 +37,16 @@ extends PHP53to54_AbstractSniffUnitTest
      *
      * @return array(int => int)
      */
-	public function getErrorList()
-	{
-		return array(
-			5 => 1,
-			10 => 1,
-			13 => 1,
-		);
-	}
+    public function getErrorList()
+    {
+        return array(
+            5 => 1,
+            10 => 1,
+            13 => 1,
+        );
+    }
 
-	/**
+    /**
      * Returns the lines where warnings should occur.
      *
      * The key of the array should represent the line number and the value
@@ -54,10 +54,10 @@ extends PHP53to54_AbstractSniffUnitTest
      *
      * @return array(int => int)
      */
-	public function getWarningList()
-	{
-		return array(
-			8 => 1,
-		);
+    public function getWarningList()
+    {
+        return array(
+            8 => 1,
+        );
     }
 }

--- a/tests/Standards/PHP53to54/Tests/Generic/ForbiddenInterfaceNamesUnitTest.php
+++ b/tests/Standards/PHP53to54/Tests/Generic/ForbiddenInterfaceNamesUnitTest.php
@@ -5,31 +5,31 @@
  *
  * PHP version 5
  *
- * @category PHP
- * @package PHP_CodeSniffer
- * @author Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
  * @copyright 2012 foobugs oelke & eichner GbR
- * @license BSD http://www.opensource.org/licenses/bsd-license.php
- * @link https://github.com/foobugs/PHP53to54
- * @since 1.0-beta
+ * @license   BSD http://www.opensource.org/licenses/bsd-license.php
+ * @link      https://github.com/foobugs/PHP53to54
+ * @since     1.0-beta
  */
 
 /**
  * Unit test class for PHP/ForbiddenInterfaceNames sniff.
  *
- * @group PHP53to54
- * @category PHP
- * @package PHP_CodeSniffer
- * @author Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
+ * @group     PHP53to54
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
  * @copyright 2012 foobugs oelke & eichner GbR
- * @license BSD http://www.opensource.org/licenses/bsd-license.php
- * @link https://github.com/foobugs/PHP53to54
- * @since 1.0-beta
+ * @license   BSD http://www.opensource.org/licenses/bsd-license.php
+ * @link      https://github.com/foobugs/PHP53to54
+ * @since     1.0-beta
  */
 class PHP53to54_Tests_Generic_ForbiddenInterfaceNamesUnitTest
-extends PHP53to54_AbstractSniffUnitTest
+extends AbstractSniffUnitTest
 {
-	/**
+    /**
      * Returns the lines where errors should occur.
      *
      * The key of the array should represent the line number and the value
@@ -37,15 +37,15 @@ extends PHP53to54_AbstractSniffUnitTest
      *
      * @return array(int => int)
      */
-	public function getErrorList()
-	{
-		return array(
-			9 => 1,
-			13 => 1,
-		);
-	}
+    public function getErrorList()
+    {
+        return array(
+            9 => 1,
+            15 => 1,
+        );
+    }
 
-	/**
+    /**
      * Returns the lines where warnings should occur.
      *
      * The key of the array should represent the line number and the value
@@ -53,9 +53,9 @@ extends PHP53to54_AbstractSniffUnitTest
      *
      * @return array(int => int)
      */
-	public function getWarningList()
-	{
-		return array(
-		);
+    public function getWarningList()
+    {
+        return array(
+        );
     }
 }

--- a/tests/Standards/PHP53to54/Tests/PHP/BreakContinueVarSyntaxUnitTest.php
+++ b/tests/Standards/PHP53to54/Tests/PHP/BreakContinueVarSyntaxUnitTest.php
@@ -5,31 +5,31 @@
  *
  * PHP version 5
  *
- * @category PHP
- * @package PHP_CodeSniffer
- * @author Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
  * @copyright 2012 foobugs oelke & eichner GbR
- * @license BSD http://www.opensource.org/licenses/bsd-license.php
- * @link https://github.com/foobugs/PHP53to54
- * @since 1.0-beta
+ * @license   BSD http://www.opensource.org/licenses/bsd-license.php
+ * @link      https://github.com/foobugs/PHP53to54
+ * @since     1.0-beta
  */
 
 /**
  * Unit test class for PHP/BreakContinueVarSyntaxSniff sniff.
  *
- * @group PHP53to54
- * @category PHP
- * @package PHP_CodeSniffer
- * @author Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
+ * @group     PHP53to54
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
  * @copyright 2012 foobugs oelke & eichner GbR
- * @license BSD http://www.opensource.org/licenses/bsd-license.php
- * @link https://github.com/foobugs/PHP53to54
- * @since 1.0-beta
+ * @license   BSD http://www.opensource.org/licenses/bsd-license.php
+ * @link      https://github.com/foobugs/PHP53to54
+ * @since     1.0-beta
  */
 class PHP53to54_Tests_PHP_BreakContinueVarSyntaxUnitTest
-extends PHP53to54_AbstractSniffUnitTest
+extends AbstractSniffUnitTest
 {
-	/**
+    /**
      * Returns the lines where errors should occur.
      *
      * The key of the array should represent the line number and the value
@@ -37,22 +37,22 @@ extends PHP53to54_AbstractSniffUnitTest
      *
      * @return array(int => int)
      */
-	public function getErrorList()
-	{
-		return array(
-		    14 => 1,
-		    19 => 1,
-			25 => 1,
-			29 => 1,
-			33 => 1,
-			37 => 1,
-			41 => 1,
-			45 => 1,
-		    49 => 1,
-		);
-	}
+    public function getErrorList()
+    {
+        return array(
+            14 => 1,
+            19 => 1,
+            25 => 1,
+            29 => 1,
+            33 => 1,
+            37 => 1,
+            41 => 1,
+            45 => 1,
+            49 => 1,
+        );
+    }
 
-	/**
+    /**
      * Returns the lines where warnings should occur.
      *
      * The key of the array should represent the line number and the value
@@ -60,9 +60,9 @@ extends PHP53to54_AbstractSniffUnitTest
      *
      * @return array(int => int)
      */
-	public function getWarningList()
-	{
-		return array(
-		);
+    public function getWarningList()
+    {
+        return array(
+        );
     }
 }

--- a/tests/Standards/PHP53to54/Tests/PHP/ForbiddenFunctionNamesUnitTest.php
+++ b/tests/Standards/PHP53to54/Tests/PHP/ForbiddenFunctionNamesUnitTest.php
@@ -5,31 +5,31 @@
  *
  * PHP version 5
  *
- * @category PHP
- * @package PHP_CodeSniffer
- * @author Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
  * @copyright 2012 foobugs oelke & eichner GbR
- * @license BSD http://www.opensource.org/licenses/bsd-license.php
- * @link https://github.com/foobugs/PHP53to54
- * @since 1.0-beta
+ * @license   BSD http://www.opensource.org/licenses/bsd-license.php
+ * @link      https://github.com/foobugs/PHP53to54
+ * @since     1.0-beta
  */
 
 /**
  * Unit test class for PHP/ForbiddenFunctionNames sniff.
  *
- * @group PHP53to54
- * @category PHP
- * @package PHP_CodeSniffer
- * @author Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
+ * @group     PHP53to54
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
  * @copyright 2012 foobugs oelke & eichner GbR
- * @license BSD http://www.opensource.org/licenses/bsd-license.php
- * @link https://github.com/foobugs/PHP53to54
- * @since 1.0-beta
+ * @license   BSD http://www.opensource.org/licenses/bsd-license.php
+ * @link      https://github.com/foobugs/PHP53to54
+ * @since     1.0-beta
  */
 class PHP53to54_Tests_PHP_ForbiddenFunctionNamesUnitTest
-extends PHP53to54_AbstractSniffUnitTest
+extends AbstractSniffUnitTest
 {
-	/**
+    /**
      * Returns the lines where errors should occur.
      *
      * The key of the array should represent the line number and the value
@@ -37,12 +37,12 @@ extends PHP53to54_AbstractSniffUnitTest
      *
      * @return array(int => int)
      */
-	public function getErrorList()
-	{
-		return array();
-	}
+    public function getErrorList()
+    {
+        return array();
+    }
 
-	/**
+    /**
      * Returns the lines where warnings should occur.
      *
      * The key of the array should represent the line number and the value
@@ -50,11 +50,11 @@ extends PHP53to54_AbstractSniffUnitTest
      *
      * @return array(int => int)
      */
-	public function getWarningList()
-	{
+    public function getWarningList()
+    {
         return array(
-			5 => 1,
-			9 => 1,
-		);
+            5 => 1,
+            9 => 1,
+        );
     }
 }

--- a/tests/Standards/PHP53to54/Tests/PHP/ForbiddenParameterUnitTest.inc
+++ b/tests/Standards/PHP53to54/Tests/PHP/ForbiddenParameterUnitTest.inc
@@ -1,25 +1,25 @@
 <?php
 
-function foo($_GET,$_POST, $_GLOBALS) {
-	
+function foo($_GET,$_POST, $GLOBALS) {
+
 }
 
 function abc(
 $GLOBALS
 ) {
-	
+
 }
 
-function bar(Array $_GET, $_POST) {
-	
+function bar(array $_GET, $_POST, callable $GLOBALS) {
+
 }
 
 function batz($foo, $bar) {
-	
+
 }
 
-$callback = 
-	function($a, $_GET) use ($x, $y) 
+$callback =
+	function($a, $_GET) use ($x, $y)
 	{
-		
+
 	};

--- a/tests/Standards/PHP53to54/Tests/PHP/ForbiddenParameterUnitTest.php
+++ b/tests/Standards/PHP53to54/Tests/PHP/ForbiddenParameterUnitTest.php
@@ -5,30 +5,30 @@
  *
  * PHP version 5
  *
- * @category PHP
- * @package PHP_CodeSniffer
- * @author Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
  * @copyright 2012 foobugs oelke & eichner GbR
- * @license BSD http://www.opensource.org/licenses/bsd-license.php
- * @link https://github.com/foobugs/PHP53to54
- * @since 1.0-beta
+ * @license   BSD http://www.opensource.org/licenses/bsd-license.php
+ * @link      https://github.com/foobugs/PHP53to54
+ * @since     1.0-beta
  */
 
 /**
  * Unit test class for PHP/ForbiddenParameter sniff.
  *
- * @group PHP53to54
- * @category PHP
- * @package PHP_CodeSniffer
- * @author Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
+ * @group     PHP53to54
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
  * @copyright 2012 foobugs oelke & eichner GbR
- * @license BSD http://www.opensource.org/licenses/bsd-license.php
- * @link https://github.com/foobugs/PHP53to54
- * @since 1.0-beta
+ * @license   BSD http://www.opensource.org/licenses/bsd-license.php
+ * @link      https://github.com/foobugs/PHP53to54
+ * @since     1.0-beta
  */
-class PHP53to54_Tests_PHP_ForbiddenParameterUnitTest extends PHP53to54_AbstractSniffUnitTest
+class PHP53to54_Tests_PHP_ForbiddenParameterUnitTest extends AbstractSniffUnitTest
 {
-	/**
+    /**
      * Returns the lines where errors should occur.
      *
      * The key of the array should represent the line number and the value
@@ -36,12 +36,12 @@ class PHP53to54_Tests_PHP_ForbiddenParameterUnitTest extends PHP53to54_AbstractS
      *
      * @return array(int => int)
      */
-	public function getErrorList()
-	{
-		return array();
-	}
-	
-	/**
+    public function getErrorList()
+    {
+        return array();
+    }
+
+    /**
      * Returns the lines where warnings should occur.
      *
      * The key of the array should represent the line number and the value
@@ -49,14 +49,13 @@ class PHP53to54_Tests_PHP_ForbiddenParameterUnitTest extends PHP53to54_AbstractS
      *
      * @return array(int => int)
      */
-	public function getWarningList()
-	{
+    public function getWarningList()
+    {
         return array(
-			3 => 3,
-			5 => 1,
-			8 => 1,
-			13 => 2,
-			22 => 1,
-		);
+            3 => 3,
+            7 => 1,
+            13 => 3,
+            22 => 1,
+        );
     }
 }

--- a/tests/Standards/PHP53to54/Tests/PHP/RemovedFunctionParametersUnitTest.inc
+++ b/tests/Standards/PHP53to54/Tests/PHP/RemovedFunctionParametersUnitTest.inc
@@ -8,3 +8,5 @@ echo hash ($algorithm);
 sprintf('%s', 'test'.hash('salsa20'));
 
 echo "Teststring".hash_file('no-match').'aslk';
+
+echo hash_file('no-match', 'gamma', 'beta', 'salsa10');

--- a/tests/Standards/PHP53to54/Tests/PHP/RemovedFunctionParametersUnitTest.php
+++ b/tests/Standards/PHP53to54/Tests/PHP/RemovedFunctionParametersUnitTest.php
@@ -5,29 +5,29 @@
  *
  * PHP version 5
  *
- * @category PHP
- * @package PHP_CodeSniffer
- * @author Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
  * @copyright 2012 foobugs oelke & eichner GbR
- * @license BSD http://www.opensource.org/licenses/bsd-license.php
- * @link https://github.com/foobugs/PHP53to54
- * @since 1.0-beta
+ * @license   BSD http://www.opensource.org/licenses/bsd-license.php
+ * @link      https://github.com/foobugs/PHP53to54
+ * @since     1.0-beta
  */
 
 /**
  * Unit test class for PHP/RemovedFunctionParameters sniff.
  *
- * @group PHP53to54
- * @category PHP
- * @package PHP_CodeSniffer
- * @author Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
+ * @group     PHP53to54
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
  * @copyright 2012 foobugs oelke & eichner GbR
- * @license BSD http://www.opensource.org/licenses/bsd-license.php
- * @link https://github.com/foobugs/PHP53to54
- * @since 1.0-beta
+ * @license   BSD http://www.opensource.org/licenses/bsd-license.php
+ * @link      https://github.com/foobugs/PHP53to54
+ * @since     1.0-beta
  */
 class PHP53to54_Tests_PHP_RemovedFunctionParametersUnitTest
-extends PHP53to54_AbstractSniffUnitTest
+extends AbstractSniffUnitTest
 {
     /**
      * Returns the lines where errors should occur.

--- a/tests/Standards/PHP53to54/Tests/PHP/RemovedMagicQuotesUnitTest.php
+++ b/tests/Standards/PHP53to54/Tests/PHP/RemovedMagicQuotesUnitTest.php
@@ -5,31 +5,31 @@
  *
  * PHP version 5
  *
- * @category PHP
- * @package PHP_CodeSniffer
- * @author Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
  * @copyright 2012 foobugs oelke & eichner GbR
- * @license BSD http://www.opensource.org/licenses/bsd-license.php
- * @link https://github.com/foobugs/PHP53to54
- * @since 1.0-beta
+ * @license   BSD http://www.opensource.org/licenses/bsd-license.php
+ * @link      https://github.com/foobugs/PHP53to54
+ * @since     1.0-beta
  */
 
 /**
  * Unit test class for PHP/RemovedFunctionParameters sniff.
  *
- * @group PHP53to54
- * @category PHP
- * @package PHP_CodeSniffer
- * @author Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
+ * @group     PHP53to54
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Marcel Eichner // foobugs <marcel.eichner@foobugs.com>
  * @copyright 2012 foobugs oelke & eichner GbR
- * @license BSD http://www.opensource.org/licenses/bsd-license.php
- * @link https://github.com/foobugs/PHP53to54
- * @since 1.0-beta
+ * @license   BSD http://www.opensource.org/licenses/bsd-license.php
+ * @link      https://github.com/foobugs/PHP53to54
+ * @since     1.0-beta
  */
 class PHP53to54_Tests_PHP_RemovedMagicQuotesUnitTest
-extends PHP53to54_AbstractSniffUnitTest
+extends AbstractSniffUnitTest
 {
-	/**
+    /**
      * Returns the lines where errors should occur.
      *
      * The key of the array should represent the line number and the value
@@ -37,16 +37,17 @@ extends PHP53to54_AbstractSniffUnitTest
      *
      * @return array(int => int)
      */
-	public function getErrorList()
-	{
-		return array(
-			4 => 1,
-			6 => 1,
-			8 => 1,
-		);
-	}
+    public function getErrorList()
+    {
+        return array(
+            // TODO deprecated error list
+            // 4 => 1,
+            // 6 => 1,
+            // 8 => 1,
+        );
+    }
 
-	/**
+    /**
      * Returns the lines where warnings should occur.
      *
      * The key of the array should represent the line number and the value
@@ -54,9 +55,11 @@ extends PHP53to54_AbstractSniffUnitTest
      *
      * @return array(int => int)
      */
-	public function getWarningList()
-	{
-		return array(
-		);
+    public function getWarningList()
+    {
+        return array(
+            4 => 1,
+            6 => 1,
+        );
     }
 }


### PR DESCRIPTION
Enforced PEAR coding standard for unit tests, updated line references and fixed an issue with forbidden argument check (first argument has offset 1, not 0).
